### PR TITLE
Prototype of `ChildrenAs` processor

### DIFF
--- a/src/Our.Umbraco.Ditto.Contrib/Collections/ChildrenAs.cs
+++ b/src/Our.Umbraco.Ditto.Contrib/Collections/ChildrenAs.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Our.Umbraco.Ditto
+{
+    public class ChildrenAs : DittoMultiProcessorAttribute
+    {
+        public ChildrenAs(string documentTypeAlias = null)
+        {
+            Attributes = new List<DittoProcessorAttribute>()
+            {
+                new UmbracoPropertyAttribute("Children"),
+                new PublishedContentByDocumentTypeAlias(documentTypeAlias)
+            };
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto.Contrib/Collections/ChildrenAs.cs
+++ b/src/Our.Umbraco.Ditto.Contrib/Collections/ChildrenAs.cs
@@ -4,12 +4,12 @@ namespace Our.Umbraco.Ditto
 {
     public class ChildrenAs : DittoMultiProcessorAttribute
     {
-        public ChildrenAs(string documentTypeAlias = null)
+        public ChildrenAs(params string[] documentTypeAliases)
         {
             Attributes = new List<DittoProcessorAttribute>()
             {
                 new UmbracoPropertyAttribute("Children"),
-                new PublishedContentByDocumentTypeAlias(documentTypeAlias)
+                new PublishedContentByDocumentTypeAlias(documentTypeAliases)
             };
         }
     }

--- a/src/Our.Umbraco.Ditto.Contrib/Collections/PublishedContentByDocumentTypeAlias.cs
+++ b/src/Our.Umbraco.Ditto.Contrib/Collections/PublishedContentByDocumentTypeAlias.cs
@@ -1,0 +1,15 @@
+﻿using Umbraco.Core;
+
+namespace Our.Umbraco.Ditto
+{
+    public class PublishedContentByDocumentTypeAlias : PublishedContentFilter
+    {
+        public PublishedContentByDocumentTypeAlias(string documentTypeAlias = null)
+        {
+            if (!string.IsNullOrWhiteSpace(documentTypeAlias))
+            {
+                Filter = x => x.DocumentTypeAlias.InvariantEquals(documentTypeAlias);
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto.Contrib/Collections/PublishedContentByDocumentTypeAlias.cs
+++ b/src/Our.Umbraco.Ditto.Contrib/Collections/PublishedContentByDocumentTypeAlias.cs
@@ -1,14 +1,15 @@
-﻿using Umbraco.Core;
+﻿using System.Linq;
+using Umbraco.Core;
 
 namespace Our.Umbraco.Ditto
 {
-    public class PublishedContentByDocumentTypeAlias : PublishedContentFilter
+    internal class PublishedContentByDocumentTypeAlias : PublishedContentFilter
     {
-        public PublishedContentByDocumentTypeAlias(string documentTypeAlias = null)
+        public PublishedContentByDocumentTypeAlias(params string[] documentTypeAliases)
         {
-            if (!string.IsNullOrWhiteSpace(documentTypeAlias))
+            if (documentTypeAliases != null && documentTypeAliases.Any())
             {
-                Filter = x => x.DocumentTypeAlias.InvariantEquals(documentTypeAlias);
+                Filter = x => documentTypeAliases.InvariantContains(x.DocumentTypeAlias);
             }
         }
     }

--- a/src/Our.Umbraco.Ditto.Contrib/Collections/PublishedContentFilter.cs
+++ b/src/Our.Umbraco.Ditto.Contrib/Collections/PublishedContentFilter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Models;
+using Umbraco.Web;
+
+namespace Our.Umbraco.Ditto
+{
+    public abstract class PublishedContentFilter : DittoProcessorAttribute
+    {
+        protected Func<IPublishedContent, bool> Filter { get; set; }
+
+        public override object ProcessValue()
+        {
+            var content = Value as IPublishedContent;
+            if (content != null)
+            {
+                return Filter != null && Filter(content)
+                    ? content
+                    : null;
+            }
+
+            var items = Value as IEnumerable<IPublishedContent>;
+            if (items != null)
+            {
+                return Filter != null
+                    ? items.Where(Filter)
+                    : items;
+            }
+
+            return Value;
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto.Contrib/Collections/PublishedContentFilter.cs
+++ b/src/Our.Umbraco.Ditto.Contrib/Collections/PublishedContentFilter.cs
@@ -6,7 +6,7 @@ using Umbraco.Web;
 
 namespace Our.Umbraco.Ditto
 {
-    public abstract class PublishedContentFilter : DittoProcessorAttribute
+    internal abstract class PublishedContentFilter : DittoProcessorAttribute
     {
         protected Func<IPublishedContent, bool> Filter { get; set; }
 

--- a/src/Our.Umbraco.Ditto.Contrib/Our.Umbraco.Ditto.Contrib.csproj
+++ b/src/Our.Umbraco.Ditto.Contrib/Our.Umbraco.Ditto.Contrib.csproj
@@ -277,10 +277,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Aggregation\AggregateValues.cs" />
+    <Compile Include="Collections\PublishedContentByDocumentTypeAlias.cs" />
+    <Compile Include="Collections\ChildrenAs.cs" />
     <Compile Include="Relations\RelationDirection.cs" />
     <Compile Include="Relations\UmbracoRelationProcessorAttribute.cs" />
     <Compile Include="Relations\UmbracoRelationAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Collections\PublishedContentFilter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/Our.Umbraco.Ditto.Contrib.Tests/ChildrenAsTests.cs
+++ b/tests/Our.Umbraco.Ditto.Contrib.Tests/ChildrenAsTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Our.Umbraco.Ditto.Contrib.Tests.Mocks;
+using Umbraco.Core.Models;
+
+namespace Our.Umbraco.Ditto.Contrib
+{
+    [TestFixture]
+    public class ChildrenAsTests
+    {
+        const string MyDocumentTypeAlias = "myDocumentTypeAlias";
+
+        public class MyModel
+        {
+            [ChildrenAs(MyDocumentTypeAlias)]
+            public IEnumerable<IPublishedContent> MyProperty { get; set; }
+        }
+
+        [Test]
+        public void ChildrenAs_Resolves()
+        {
+            var content = new MockPublishedContent
+            {
+                Children = new[]
+                {
+                    new MockPublishedContent { Id = 1111, Name = "Item 1", DocumentTypeAlias = MyDocumentTypeAlias },
+                    new MockPublishedContent { Id = 2222, Name = "Item 2", DocumentTypeAlias = "myDifferentDocumentTypeAlias" },
+                    new MockPublishedContent { Id = 3333, Name = "Item 3", DocumentTypeAlias = MyDocumentTypeAlias },
+                }
+            };
+
+            var model = content.As<MyModel>();
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model.MyProperty, Is.Not.Null);
+
+            var list = model.MyProperty.ToList();
+
+            Assert.That(list, Has.Count);
+            Assert.That(list.Count, Is.EqualTo(2));
+            Assert.That(list.First().Id, Is.EqualTo(1111));
+            Assert.That(list.Last().Id, Is.EqualTo(3333));
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Contrib.Tests/Our.Umbraco.Ditto.Contrib.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Contrib.Tests/Our.Umbraco.Ditto.Contrib.Tests.csproj
@@ -308,6 +308,7 @@
     <Compile Include="Mocks\MockPublishedContent.cs" />
     <Compile Include="Mocks\MockPublishedProperty.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ChildrenAsTests.cs" />
     <Compile Include="UmbracoRelationProcessorTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Our.Umbraco.Ditto.Contrib.Tests/UmbracoRelationProcessorTests.cs
+++ b/tests/Our.Umbraco.Ditto.Contrib.Tests/UmbracoRelationProcessorTests.cs
@@ -6,7 +6,6 @@ using Moq;
 using NUnit.Framework;
 using Our.Umbraco.Ditto.Contrib.Tests.Mocks;
 using Umbraco.Core;
-using Umbraco.Core.Cache;
 using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;


### PR DESCRIPTION
Includes abstract processor `PublishedContentFilter`, which can be used to pass in a Where clause to filter out from a collection of nodes.
